### PR TITLE
Add Mapbox tileset upload process

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 brew install gdal python3 parallel node tippecanoe
-pip3 install fiona csv json
+pip3 install fiona csv json mapbox
 npm install turf @turf/random @turf/points-within-polygon @mapbox/polylabel
 
 mkdir -p data

--- a/script/server
+++ b/script/server
@@ -1,1 +1,4 @@
 #!/bin/sh
+
+# Upload tiles to Mapbox
+python3 src/upload-tiles.py

--- a/src/upload-tiles.py
+++ b/src/upload-tiles.py
@@ -1,0 +1,32 @@
+import os
+from time import sleep
+
+from mapbox import Uploader
+service = Uploader()
+
+dir = os.path.dirname(__file__)
+
+tilesets = [
+  { 'mapid': 'habitat-areas-2017', 'path': os.path.join(dir, '..', 'tiles', 'habitat-areas.mbtiles') },
+  { 'mapid': 'sightings-2017',     'path': os.path.join(dir, '..', 'tiles', 'sightings.mbtiles') },
+]
+
+for tileset in tilesets:
+    with open(tileset['path'], 'rb') as src:
+        upload_resp = service.upload(src, tileset['mapid'])
+        tileset['upload_id'] = upload_resp.json()['id']
+        print('Uploading:')
+        print(upload_resp.json())
+
+def uploads_complete(tileset_list):
+    statuses = []
+    for tileset in tileset_list:
+        statuses.append(service.status(tileset['upload_id']).json()['complete'])
+    return all(statuses)
+
+print('Processing uploads... Check status at https://www.mapbox.com/studio/tilesets/')
+
+while not uploads_complete(tilesets):
+    sleep(10)
+
+print('Uploads complete!')


### PR DESCRIPTION
### Overview
- adds script for uploading tilesets to a Mapbox account
- adds Mapbox SDK to `script/bootstrap`

### Testing

- set write-scope mapbox access token: `export MAPBOX_ACCESS_TOKEN="YOUR_ACCESS_TOKEN"`
- run `script/server` to upload MBTiles files generated from `script/setup`
- watch https://www.mapbox.com/studio/tilesets/ for upload status