### PR TITLE
Downgrade Ubuntu version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.04
+FROM ubuntu:16.04
 
 # Install Python and other dependencies
 RUN apt-get update -y && \


### PR DESCRIPTION
The previous Ubuntu version that was used as the base image was causing an error - moved to a version that allowed the container to build.