### PR TITLE
Avoid splitting polygons

### DIFF
--- a/src/app/config.js
+++ b/src/app/config.js
@@ -2,7 +2,7 @@
 const MAPBOX_ACCESS_TOKEN = 'pk.eyJ1Ijoibmp3aWxkbGlmZS1hemF2ZWEiLCJhIjoiY2pnemY2dXQ1MTBocDJ3bGxmdmU5YThzcCJ9.hmeBcIvcdhkCHc3LFZ2zlw';
 
 // This where the app will look for the individual GeoJSON files.
-const HOST = 'https://s3.amazonaws.com/nj-wildlife-habitat-vector-tile-map';
+const HOST = 'https://s3.amazonaws.com/nj-wildlife-demo';
 
 // URLs to the tile source TileJSON resources. Supported protocols are http:, https:, and mapbox://<mapid>.
 const TILE_SOURCES = {

--- a/src/data-prep/scripts/prepare-app-data.sh
+++ b/src/data-prep/scripts/prepare-app-data.sh
@@ -11,6 +11,7 @@ mkdir -p /usr/src/data/habitat
 # Habitat Polygon Vector Tiles
 # Read habitat features and convert to vector tiles
 tippecanoe --read-parallel \
+  --no-polygon-splitting \
   -n "NJ Landscape Project Habitat Areas" -A "<a href='http://www.state.nj.us/dep/fgw/ensp/landscape/index.htm'>NJDEP</a>" \
   -l "nj-habitat-areas" -z 14 -Z 12 \
   -f -o /usr/src/data/nj-habitat-areas.mbtiles \
@@ -35,6 +36,7 @@ function export-mbtiles() {
 
 
 tippecanoe --read-parallel \
+  --no-polygon-splitting \
   -n "NJ Landscape Project Regions" -A "<a href='http://www.state.nj.us/dep/fgw/ensp/landscape/index.htm'>NJDEP</a>" \
   -l "landscape-regions" -z 13 -Z 7 \
   -f -o /usr/src/data/landscape-regions.mbtiles \


### PR DESCRIPTION
The option --no-polygon-splitting exists explicitly to resolve the artifacts described in issue #65. I'm unable to test this change (and it will likely decrease the performance of vector tile generation non-trivially), but I believe it should be sufficient.

Closes #65 