### PR TITLE
Add empty habitat list array

### DIFF
--- a/src/app/index.html
+++ b/src/app/index.html
@@ -648,6 +648,7 @@ function renderSelectAreaOfInterestPrompt() {
 
 // Render Application State 2: Report on user's selected area of interest
 let fullList = [];
+let uniquesList = [];
 
 function renderAreaOfInterestReport() {
 
@@ -683,7 +684,7 @@ function renderAreaOfInterestReport() {
       }
   };
 
-  let uniquesList = removeDuplicates(fullList, 'COMNAME');
+  uniquesList = removeDuplicates(fullList, 'COMNAME');
 
   const appState2 =
       '<div class="sidebar" id="app-state-2"> \


### PR DESCRIPTION
There was a repetitive issue where upon drawing a new Area of Interest in a different region, a user would receive the same habitat list. Adding the empty array line clears the list.